### PR TITLE
Use code blocks for the AND and OR examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ levels.forEach((lvl, i) => {
     --red-if-toggler: var(--toggler) red;
     background: var(--red-if-toggler, green); /* will be green! */
   ```
-* Space Toggles can be combined for AND logic: `--red-if-togglersalltrue: var(--tog1) var(--tog2) var(--tog3) red;`
-* Space Toggles can be combined for OR logic: `--red-if-anytogglertrue: var(--tog1, var(--tog2, var(--tog3))) red;`
+* Space Toggles can be combined for AND logic: 
+  ```css
+    --red-if-togglersalltrue: var(--tog1) var(--tog2) var(--tog3) red;
+  ```
+* Space Toggles can be combined for OR logic: 
+  ```css
+    --red-if-anytogglertrue: var(--tog1, var(--tog2, var(--tog3))) red;
+  ```
 * Checkboxes (and radio buttons) make a great source for space toggles (shout out to <a href="https://twitter.com/RockStarwind">@RockStarwind</a> for that idea)
   ```css
     #common-css-var-area { /* default any "not" values to truthy */ --not-flagged: ; }


### PR DESCRIPTION
This should make it less likely for the example to break across multiple lines, plus it matches nicer with the other examples in this section 😁

Before:
![Screen Shot 2020-07-29 at 8 49 51 AM](https://user-images.githubusercontent.com/4369687/88828257-d1417080-d17f-11ea-9a3d-96cecba9b562.png)
After:
<img width="953" alt="Screen Shot 2020-07-29 at 9 40 05 AM" src="https://user-images.githubusercontent.com/4369687/88828249-cf77ad00-d17f-11ea-9d6f-68772a2d4146.png">
